### PR TITLE
feat(ui): dark theme TCG — navy, gold y orange

### DIFF
--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -1,6 +1,6 @@
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen flex items-center justify-center bg-bg">
       <div className="w-full max-w-md">{children}</div>
     </div>
   );

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -44,10 +44,10 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
+    <div className="bg-surface rounded-2xl border border-surface-border p-8">
       <div className="mb-8 text-center">
-        <h1 className="text-2xl font-bold text-gray-900">Bienvenido a CardBuy</h1>
-        <p className="mt-1 text-sm text-gray-500">Inicia sesión en tu cuenta</p>
+        <h1 className="font-display text-2xl font-bold text-white">Bienvenido a CardBuy</h1>
+        <p className="mt-1 text-sm text-slate-400">Inicia sesión en tu cuenta</p>
       </div>
 
       <Button
@@ -102,9 +102,9 @@ export default function LoginPage() {
         </Button>
       </form>
 
-      <p className="mt-6 text-center text-sm text-gray-500">
+      <p className="mt-6 text-center text-sm text-slate-400">
         ¿No tienes cuenta?{" "}
-        <Link href="/register" className="font-medium text-blue-600 hover:underline">
+        <Link href="/register" className="font-medium text-brand hover:text-brand-light transition-colors">
           Regístrate gratis
         </Link>
       </p>

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -56,10 +56,10 @@ export default function RegisterPage() {
   }
 
   return (
-    <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
+    <div className="bg-surface rounded-2xl border border-surface-border p-8">
       <div className="mb-8 text-center">
-        <h1 className="text-2xl font-bold text-gray-900">Crear cuenta en CardBuy</h1>
-        <p className="mt-1 text-sm text-gray-500">El marketplace de cartas TCG de confianza</p>
+        <h1 className="font-display text-2xl font-bold text-white">Crear cuenta en CardBuy</h1>
+        <p className="mt-1 text-sm text-slate-400">El marketplace de cartas TCG de confianza</p>
       </div>
 
       <Button
@@ -120,7 +120,7 @@ export default function RegisterPage() {
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Mín. 8 caracteres, 1 mayúscula y 1 número"
           />
-          <p className="mt-1 text-xs text-gray-400">
+          <p className="mt-1 text-xs text-slate-500">
             Mínimo 8 caracteres, una mayúscula y un número
           </p>
         </div>
@@ -130,9 +130,9 @@ export default function RegisterPage() {
         </Button>
       </form>
 
-      <p className="mt-6 text-center text-sm text-gray-500">
+      <p className="mt-6 text-center text-sm text-slate-400">
         ¿Ya tienes cuenta?{" "}
-        <Link href="/login" className="font-medium text-blue-600 hover:underline">
+        <Link href="/login" className="font-medium text-brand hover:text-brand-light transition-colors">
           Inicia sesión
         </Link>
       </p>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -4,16 +4,34 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --background: #0d1525;
+    --foreground: #f1f5f9;
   }
 
   body {
     font-family: var(--font-inter), system-ui, sans-serif;
+    background-color: #0d1525;
+    color: #f1f5f9;
   }
 
   h1, h2, h3, h4, h5, h6 {
     font-family: var(--font-display), system-ui, sans-serif;
+  }
+
+  /* Scrollbar personalizada */
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  ::-webkit-scrollbar-track {
+    background: #080f1c;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: #1e3050;
+    border-radius: 3px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: #f0a500;
   }
 }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -47,7 +47,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="es" className={`${inter.variable} ${plusJakartaSans.variable}`}>
-      <body className="flex min-h-screen flex-col bg-white font-sans">
+      <body className="flex min-h-screen flex-col bg-bg font-sans">
         <Providers>
           <Navbar />
           <main className="flex-1">{children}</main>

--- a/apps/web/src/app/listings/page.tsx
+++ b/apps/web/src/app/listings/page.tsx
@@ -38,8 +38,8 @@ export default function ListingsPage({ searchParams }: Props) {
   return (
     <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{gameLabel}</h1>
-        <p className="text-sm text-gray-500 mt-1">
+        <h1 className="font-display text-2xl font-bold text-white">{gameLabel}</h1>
+        <p className="text-sm text-slate-400 mt-1">
           {PLACEHOLDER_LISTINGS.length} carta{PLACEHOLDER_LISTINGS.length !== 1 ? "s" : ""} disponible
           {PLACEHOLDER_LISTINGS.length !== 1 ? "s" : ""}
         </p>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -14,22 +14,28 @@ export default function HomePage() {
   return (
     <>
       {/* Hero */}
-      <section className="bg-gradient-to-b from-brand-50 to-white py-20 px-4">
-        <div className="mx-auto max-w-3xl text-center">
-          <Badge variant="info" className="mb-4">
+      <section className="relative bg-hero-gradient py-24 px-4 overflow-hidden">
+        {/* Glow decorativo */}
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] bg-brand/5 rounded-full blur-3xl" />
+          <div className="absolute top-1/2 right-1/4 w-[300px] h-[300px] bg-accent/5 rounded-full blur-3xl" />
+        </div>
+
+        <div className="relative mx-auto max-w-3xl text-center">
+          <Badge variant="gold" className="mb-5">
             Marketplace TCG de confianza
           </Badge>
-          <h1 className="font-display text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+          <h1 className="font-display text-4xl font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">
             Compra y vende cartas TCG{" "}
-            <span className="text-brand-600">con seguridad</span>
+            <span className="text-brand">con seguridad</span>
           </h1>
-          <p className="mt-6 text-lg text-gray-600">
+          <p className="mt-6 text-lg text-slate-400 max-w-2xl mx-auto">
             Vendedores verificados, pago protegido y gestión de disputas. El marketplace
             para coleccionistas y jugadores de Pokémon, Magic, Yu-Gi-Oh! y más.
           </p>
           <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
             <Link href="/listings">
-              <Button size="lg">Ver cartas en venta</Button>
+              <Button variant="primary" size="lg">Ver cartas en venta</Button>
             </Link>
             <Link href="/register">
               <Button variant="secondary" size="lg">
@@ -43,18 +49,18 @@ export default function HomePage() {
       {/* Juegos */}
       <section className="py-16 px-4">
         <div className="mx-auto max-w-7xl">
-          <h2 className="text-2xl font-bold text-gray-900 text-center mb-10">
+          <h2 className="font-display text-2xl font-bold text-white text-center mb-10">
             Explora por juego
           </h2>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
             {GAMES.map((game) => (
               <Link
                 key={game.href}
                 href={game.href}
-                className="flex flex-col items-center gap-2 rounded-xl border border-gray-200 bg-white p-4 text-center transition-shadow hover:shadow-md hover:border-brand-200"
+                className="flex flex-col items-center gap-2 rounded-xl border border-surface-border bg-surface p-4 text-center transition-all duration-200 hover:border-brand/40 hover:bg-surface-hover hover:shadow-glow-card"
               >
                 <span className="text-3xl">{game.emoji}</span>
-                <span className="text-sm font-medium text-gray-700">{game.name}</span>
+                <span className="text-sm font-medium text-slate-300 group-hover:text-white">{game.name}</span>
               </Link>
             ))}
           </div>
@@ -62,23 +68,23 @@ export default function HomePage() {
       </section>
 
       {/* Trust signals */}
-      <section className="bg-gray-50 py-16 px-4">
+      <section className="py-16 px-4 border-t border-surface-border">
         <div className="mx-auto max-w-7xl">
           <div className="grid grid-cols-1 gap-8 sm:grid-cols-3 text-center">
-            <div>
-              <div className="text-3xl font-bold text-brand-600">✓</div>
-              <h3 className="mt-2 font-semibold text-gray-900">Vendedores verificados</h3>
-              <p className="mt-1 text-sm text-gray-500">KYC obligatorio para todos los vendedores</p>
+            <div className="flex flex-col items-center gap-3">
+              <div className="w-12 h-12 rounded-full bg-brand/15 flex items-center justify-center text-2xl">✓</div>
+              <h3 className="font-semibold text-white">Vendedores verificados</h3>
+              <p className="text-sm text-slate-500">KYC obligatorio para todos los vendedores</p>
             </div>
-            <div>
-              <div className="text-3xl font-bold text-brand-600">🔒</div>
-              <h3 className="mt-2 font-semibold text-gray-900">Pago protegido</h3>
-              <p className="mt-1 text-sm text-gray-500">El dinero se libera al confirmar la recepción</p>
+            <div className="flex flex-col items-center gap-3">
+              <div className="w-12 h-12 rounded-full bg-accent/15 flex items-center justify-center text-2xl">🔒</div>
+              <h3 className="font-semibold text-white">Pago protegido</h3>
+              <p className="text-sm text-slate-500">El dinero se libera al confirmar la recepción</p>
             </div>
-            <div>
-              <div className="text-3xl font-bold text-brand-600">⭐</div>
-              <h3 className="mt-2 font-semibold text-gray-900">Sistema de reputación</h3>
-              <p className="mt-1 text-sm text-gray-500">Valoraciones verificadas de compradores reales</p>
+            <div className="flex flex-col items-center gap-3">
+              <div className="w-12 h-12 rounded-full bg-brand/15 flex items-center justify-center text-2xl">⭐</div>
+              <h3 className="font-semibold text-white">Sistema de reputación</h3>
+              <p className="text-sm text-slate-500">Valoraciones verificadas de compradores reales</p>
             </div>
           </div>
         </div>

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -10,20 +10,20 @@ const games = [
 
 export function Footer() {
   return (
-    <footer className="border-t border-gray-200 bg-gray-50 mt-auto">
+    <footer className="border-t border-surface-border bg-bg-deep mt-auto">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
           {/* Marca */}
           <div>
-            <span className="text-lg font-bold text-brand-700">CardBuy</span>
-            <p className="mt-2 text-sm text-gray-500">
+            <span className="font-display text-lg font-bold text-brand">CardBuy</span>
+            <p className="mt-2 text-sm text-slate-500">
               El marketplace de cartas coleccionables de confianza. Compra y vende con seguridad.
             </p>
           </div>
 
           {/* Juegos */}
           <div>
-            <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wide mb-3">
+            <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-3">
               Juegos
             </h3>
             <ul className="space-y-2">
@@ -31,7 +31,7 @@ export function Footer() {
                 <li key={game.href}>
                   <Link
                     href={game.href}
-                    className="text-sm text-gray-500 hover:text-gray-900 transition-colors"
+                    className="text-sm text-slate-500 hover:text-brand transition-colors"
                   >
                     {game.label}
                   </Link>
@@ -42,17 +42,17 @@ export function Footer() {
 
           {/* Legal */}
           <div>
-            <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wide mb-3">
+            <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-3">
               Legal
             </h3>
             <ul className="space-y-2">
               <li>
-                <Link href="/terms" className="text-sm text-gray-500 hover:text-gray-900 transition-colors">
+                <Link href="/terms" className="text-sm text-slate-500 hover:text-brand transition-colors">
                   Términos de uso
                 </Link>
               </li>
               <li>
-                <Link href="/privacy" className="text-sm text-gray-500 hover:text-gray-900 transition-colors">
+                <Link href="/privacy" className="text-sm text-slate-500 hover:text-brand transition-colors">
                   Privacidad
                 </Link>
               </li>
@@ -60,8 +60,8 @@ export function Footer() {
           </div>
         </div>
 
-        <div className="mt-8 border-t border-gray-200 pt-6 text-center">
-          <p className="text-xs text-gray-400">
+        <div className="mt-8 border-t border-surface-border pt-6 text-center">
+          <p className="text-xs text-slate-600">
             © {new Date().getFullYear()} CardBuy. Todos los derechos reservados.
           </p>
         </div>

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -2,53 +2,57 @@
 
 import Link from "next/link";
 import { useSession, signOut } from "next-auth/react";
+import { usePathname } from "next/navigation";
 import { Button } from "@cardbuy/ui";
+
+const NAV_LINKS = [
+  { label: "Cartas", href: "/listings" },
+  { label: "Pokémon", href: "/listings?game=pokemon" },
+  { label: "Magic", href: "/listings?game=magic" },
+  { label: "Yu-Gi-Oh!", href: "/listings?game=yugioh" },
+];
 
 export function Navbar() {
   const { data: session, status } = useSession();
+  const pathname = usePathname();
 
   return (
-    <nav className="sticky top-0 z-50 border-b border-gray-200 bg-white/95 backdrop-blur-sm">
+    <nav className="sticky top-0 z-50 border-b border-surface-border bg-bg/90 backdrop-blur-md">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}
-          <Link href="/" className="flex items-center gap-2">
-            <span className="text-xl font-bold text-brand-700">CardBuy</span>
+          <Link href="/" className="flex items-center gap-2 group">
+            <span className="font-display text-xl font-bold text-brand group-hover:text-brand-light transition-colors">
+              CardBuy
+            </span>
           </Link>
 
           {/* Links principales */}
-          <div className="hidden items-center gap-6 md:flex">
-            <Link
-              href="/listings"
-              className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900"
-            >
-              Cartas
-            </Link>
-            <Link
-              href="/listings?game=pokemon"
-              className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900"
-            >
-              Pokémon
-            </Link>
-            <Link
-              href="/listings?game=magic"
-              className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900"
-            >
-              Magic
-            </Link>
-            <Link
-              href="/listings?game=yugioh"
-              className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900"
-            >
-              Yu-Gi-Oh!
-            </Link>
+          <div className="hidden items-center gap-1 md:flex">
+            {NAV_LINKS.map((link) => {
+              const isActive = pathname === link.href || pathname?.startsWith(link.href.split("?")[0]);
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={[
+                    "px-3 py-1.5 text-sm font-medium rounded-md transition-colors relative",
+                    isActive
+                      ? "text-white after:absolute after:bottom-0 after:left-3 after:right-3 after:h-0.5 after:bg-accent after:rounded-full"
+                      : "text-slate-400 hover:text-white hover:bg-surface",
+                  ].join(" ")}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
           </div>
 
           {/* Auth */}
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
             {status === "loading" ? null : session ? (
               <>
-                <span className="hidden text-sm text-gray-600 sm:block">
+                <span className="hidden text-sm text-slate-400 sm:block">
                   {session.user?.name ?? session.user?.email}
                 </span>
                 <Button
@@ -67,7 +71,7 @@ export function Navbar() {
                   </Button>
                 </Link>
                 <Link href="/register">
-                  <Button size="sm">Registrarse</Button>
+                  <Button variant="primary" size="sm">Registrarse</Button>
                 </Link>
               </>
             )}

--- a/apps/web/src/components/listings/CardListingCard.tsx
+++ b/apps/web/src/components/listings/CardListingCard.tsx
@@ -36,27 +36,29 @@ export function CardListingCard({ listing }: Props) {
   return (
     <Link
       href={`/listings/${listing.id}`}
-      className="group flex flex-col rounded-xl border border-gray-200 bg-white overflow-hidden transition-shadow hover:shadow-md"
+      className="group flex flex-col rounded-xl border border-surface-border bg-surface overflow-hidden transition-all duration-200 hover:border-brand/40 hover:shadow-glow-card hover:-translate-y-0.5"
     >
       {/* Imagen */}
-      <div className="aspect-[3/4] bg-gray-100 relative overflow-hidden">
+      <div className="aspect-[3/4] bg-bg-deep relative overflow-hidden">
         {listing.imageUrl ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={listing.imageUrl}
             alt={listing.title}
-            className="h-full w-full object-cover group-hover:scale-105 transition-transform duration-200"
+            className="h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
           />
         ) : (
-          <div className="flex h-full items-center justify-center text-gray-300 text-4xl">
+          <div className="flex h-full items-center justify-center text-slate-700 text-4xl">
             🃏
           </div>
         )}
+        {/* Gradient overlay en la parte inferior */}
+        <div className="absolute inset-0 bg-card-gradient opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
       </div>
 
       {/* Info */}
       <div className="p-3 flex flex-col gap-1.5">
-        <h3 className="text-sm font-medium text-gray-900 line-clamp-2 leading-tight">
+        <h3 className="text-sm font-medium text-slate-200 line-clamp-2 leading-tight">
           {listing.title}
         </h3>
 
@@ -68,10 +70,10 @@ export function CardListingCard({ listing }: Props) {
         </div>
 
         <div className="flex items-center justify-between mt-1">
-          <span className="text-base font-bold text-gray-900">
+          <span className="text-base font-bold text-white">
             {listing.price.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
           </span>
-          <span className="text-xs text-gray-400 truncate max-w-[80px]">
+          <span className="text-xs text-slate-500 truncate max-w-[80px]">
             {listing.sellerName}
           </span>
         </div>

--- a/apps/web/src/components/listings/FilterPanel.tsx
+++ b/apps/web/src/components/listings/FilterPanel.tsx
@@ -56,16 +56,18 @@ export function FilterPanel() {
   );
 
   const selectClass =
-    "w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent";
+    "w-full rounded-lg border border-surface-border bg-surface px-3 py-2 text-sm text-slate-200 " +
+    "focus:outline-none focus:ring-2 focus:ring-brand/50 focus:border-brand/50 " +
+    "transition-colors [&>option]:bg-surface [&>option]:text-slate-200";
 
   return (
     <aside className="space-y-4">
-      <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
+      <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-widest">
         Filtros
       </h2>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Juego</label>
+        <label className="block text-sm font-medium text-slate-300 mb-1">Juego</label>
         <select
           className={selectClass}
           value={searchParams.get("game") ?? ""}
@@ -80,7 +82,7 @@ export function FilterPanel() {
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Condición</label>
+        <label className="block text-sm font-medium text-slate-300 mb-1">Condición</label>
         <select
           className={selectClass}
           value={searchParams.get("condition") ?? ""}
@@ -95,7 +97,7 @@ export function FilterPanel() {
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Idioma</label>
+        <label className="block text-sm font-medium text-slate-300 mb-1">Idioma</label>
         <select
           className={selectClass}
           value={searchParams.get("language") ?? ""}

--- a/apps/web/src/components/listings/ListingsGrid.tsx
+++ b/apps/web/src/components/listings/ListingsGrid.tsx
@@ -9,8 +9,8 @@ export function ListingsGrid({ listings }: Props) {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-center">
         <span className="text-5xl mb-4">🃏</span>
-        <h3 className="text-lg font-semibold text-gray-900">No hay cartas disponibles</h3>
-        <p className="mt-1 text-sm text-gray-500">
+        <h3 className="text-lg font-semibold text-white">No hay cartas disponibles</h3>
+        <p className="mt-1 text-sm text-slate-400">
           Prueba a cambiar los filtros o vuelve más tarde.
         </p>
       </div>

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -10,36 +10,57 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        // Brand colors CardBuy
+        // Paleta oscura principal — dark navy TCG
         brand: {
-          50: "#f0f4ff",
-          100: "#e0e9ff",
-          500: "#3b5bdb",
-          600: "#2f4ac7",
-          700: "#2340b0",
-          900: "#1a2f80",
+          DEFAULT: "#f0a500",   // gold ámbar — logo y acentos de marca
+          light:   "#f5c842",   // gold claro — hover de elementos dorados
+          dark:    "#c47f00",   // gold oscuro — estados pressed
         },
-        // Raridades TCG (colores semánticos)
+        accent: {
+          DEFAULT: "#e85d04",   // naranja — CTA primario
+          hover:   "#d44f00",   // naranja oscuro — hover
+          light:   "#ff7520",   // naranja claro — glow
+        },
+        surface: {
+          DEFAULT: "#131f35",   // panel oscuro
+          hover:   "#1a2a45",   // panel hover
+          raised:  "#1e2f4a",   // panel elevado (modales, dropdowns)
+          border:  "#1e3050",   // borde sutil
+        },
+        bg: {
+          DEFAULT: "#0d1525",   // fondo base
+          deep:    "#080f1c",   // fondo más oscuro (footer)
+        },
+        // Raridades TCG — ajustadas para tema oscuro
         rarity: {
-          common: "#6b7280",
-          uncommon: "#059669",
-          rare: "#2563eb",
-          ultraRare: "#7c3aed",
-          secret: "#d97706",
-          hyper: "#dc2626",
+          common:   "#94a3b8",
+          uncommon: "#34d399",
+          rare:     "#60a5fa",
+          ultraRare:"#a78bfa",
+          secret:   "#fbbf24",
+          hyper:    "#f87171",
         },
         // Condiciones de carta
         condition: {
-          nm: "#059669",    // Near Mint
-          lp: "#16a34a",    // Lightly Played
-          mp: "#ca8a04",    // Moderately Played
-          hp: "#ea580c",    // Heavily Played
-          dmg: "#dc2626",   // Damaged
+          nm:  "#34d399",   // Near Mint — verde esmeralda
+          lp:  "#4ade80",   // Lightly Played
+          mp:  "#fbbf24",   // Moderately Played — ámbar
+          hp:  "#fb923c",   // Heavily Played — naranja
+          dmg: "#f87171",   // Damaged — rojo
         },
       },
       fontFamily: {
-        sans: ["var(--font-inter)", "system-ui", "sans-serif"],
-        display: ["var(--font-cal-sans)", "system-ui", "sans-serif"],
+        sans:    ["var(--font-inter)", "system-ui", "sans-serif"],
+        display: ["var(--font-display)", "system-ui", "sans-serif"],
+      },
+      boxShadow: {
+        "glow-gold":   "0 0 20px rgba(240, 165, 0, 0.25)",
+        "glow-accent": "0 0 20px rgba(232, 93, 4, 0.3)",
+        "glow-card":   "0 0 12px rgba(240, 165, 0, 0.15)",
+      },
+      backgroundImage: {
+        "hero-gradient": "linear-gradient(135deg, #0d1525 0%, #0f1e38 50%, #0d1525 100%)",
+        "card-gradient": "linear-gradient(to top, rgba(13,21,37,0.95) 0%, transparent 60%)",
       },
     },
   },

--- a/packages/ui/src/components/Alert.tsx
+++ b/packages/ui/src/components/Alert.tsx
@@ -9,10 +9,10 @@ interface AlertProps {
 }
 
 const variantClasses: Record<AlertVariant, string> = {
-  error: "bg-red-50 border-red-200 text-red-700",
-  success: "bg-green-50 border-green-200 text-green-700",
-  warning: "bg-yellow-50 border-yellow-200 text-yellow-800",
-  info: "bg-blue-50 border-blue-200 text-blue-700",
+  error:   "bg-red-500/15 border-red-500/30 text-red-300",
+  success: "bg-emerald-500/15 border-emerald-500/30 text-emerald-300",
+  warning: "bg-amber-500/15 border-amber-500/30 text-amber-300",
+  info:    "bg-blue-500/15 border-blue-500/30 text-blue-300",
 };
 
 export function Alert({ variant = "error", children, className = "" }: AlertProps) {

--- a/packages/ui/src/components/Badge.tsx
+++ b/packages/ui/src/components/Badge.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-type BadgeVariant = "default" | "success" | "warning" | "danger" | "info" | "outline";
+type BadgeVariant = "default" | "success" | "warning" | "danger" | "info" | "outline" | "gold";
 
 interface BadgeProps {
   variant?: BadgeVariant;
@@ -9,12 +9,13 @@ interface BadgeProps {
 }
 
 const variantClasses: Record<BadgeVariant, string> = {
-  default: "bg-gray-100 text-gray-700",
-  success: "bg-green-100 text-green-700",
-  warning: "bg-yellow-100 text-yellow-800",
-  danger: "bg-red-100 text-red-700",
-  info: "bg-blue-100 text-blue-700",
-  outline: "border border-gray-300 text-gray-600",
+  default: "bg-surface-raised text-slate-300 border border-surface-border",
+  success: "bg-emerald-500/20 text-emerald-300 border border-emerald-500/30",
+  warning: "bg-amber-500/20 text-amber-300 border border-amber-500/30",
+  danger:  "bg-red-500/20 text-red-300 border border-red-500/30",
+  info:    "bg-blue-500/20 text-blue-300 border border-blue-500/30",
+  outline: "border border-surface-border text-slate-400",
+  gold:    "bg-brand/20 text-brand border border-brand/30",
 };
 
 export function Badge({ variant = "default", children, className = "" }: BadgeProps) {

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+type ButtonVariant = "primary" | "brand" | "secondary" | "ghost" | "danger";
 type ButtonSize = "sm" | "md" | "lg";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -11,20 +11,27 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const variantClasses: Record<ButtonVariant, string> = {
+  // Naranja — CTA principal
   primary:
-    "bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-300",
+    "bg-accent text-white hover:bg-accent-hover shadow-glow-accent disabled:bg-accent/40",
+  // Dorado — acciones de marca
+  brand:
+    "bg-brand text-bg font-bold hover:bg-brand-light shadow-glow-gold disabled:bg-brand/40",
+  // Contorno oscuro — acción secundaria
   secondary:
-    "bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 disabled:opacity-50",
+    "bg-transparent text-slate-200 border border-surface-border hover:bg-surface hover:border-brand/50 disabled:opacity-40",
+  // Sin fondo — navegación y acciones terciarias
   ghost:
-    "bg-transparent text-gray-700 hover:bg-gray-100 disabled:opacity-50",
+    "bg-transparent text-slate-300 hover:bg-surface hover:text-white disabled:opacity-40",
+  // Rojo — acciones destructivas
   danger:
-    "bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300",
+    "bg-red-600 text-white hover:bg-red-700 disabled:bg-red-600/40",
 };
 
 const sizeClasses: Record<ButtonSize, string> = {
   sm: "px-3 py-1.5 text-xs",
   md: "px-4 py-2.5 text-sm",
-  lg: "px-5 py-3 text-base",
+  lg: "px-6 py-3 text-base",
 };
 
 export function Button({
@@ -40,7 +47,7 @@ export function Button({
     <button
       disabled={disabled || loading}
       className={[
-        "inline-flex items-center justify-center gap-2 rounded-lg font-semibold transition-colors",
+        "inline-flex items-center justify-center gap-2 rounded-lg font-semibold transition-all duration-150",
         "disabled:cursor-not-allowed",
         variantClasses[variant],
         sizeClasses[size],
@@ -54,7 +61,6 @@ export function Button({
   );
 }
 
-// Inline Spinner to avoid circular dep
 function Spinner({ size }: { size: "sm" }) {
   return (
     <svg
@@ -64,19 +70,8 @@ function Spinner({ size }: { size: "sm" }) {
       viewBox="0 0 24 24"
       aria-hidden="true"
     >
-      <circle
-        className="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        strokeWidth="4"
-      />
-      <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-      />
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
     </svg>
   );
 }

--- a/packages/ui/src/components/Card.tsx
+++ b/packages/ui/src/components/Card.tsx
@@ -4,13 +4,16 @@ interface CardProps {
   children: React.ReactNode;
   className?: string;
   padding?: boolean;
+  glow?: boolean;
 }
 
-export function Card({ children, className = "", padding = true }: CardProps) {
+export function Card({ children, className = "", padding = true, glow = false }: CardProps) {
   return (
     <div
       className={[
-        "rounded-2xl border border-gray-200 bg-white shadow-sm",
+        "rounded-xl border border-surface-border bg-surface shadow-sm",
+        "transition-all duration-200",
+        glow ? "hover:border-brand/40 hover:shadow-glow-card" : "hover:border-surface-raised",
         padding ? "p-6" : "",
         className,
       ].join(" ")}
@@ -30,7 +33,7 @@ export function CardHeader({ children, className = "" }: { children: React.React
 
 export function CardTitle({ children, className = "" }: { children: React.ReactNode; className?: string }) {
   return (
-    <h3 className={["text-lg font-semibold text-gray-900", className].join(" ")}>
+    <h3 className={["text-lg font-semibold text-white", className].join(" ")}>
       {children}
     </h3>
   );
@@ -42,7 +45,7 @@ export function CardContent({ children, className = "" }: { children: React.Reac
 
 export function CardFooter({ children, className = "" }: { children: React.ReactNode; className?: string }) {
   return (
-    <div className={["mt-4 pt-4 border-t border-gray-100", className].join(" ")}>
+    <div className={["mt-4 pt-4 border-t border-surface-border", className].join(" ")}>
       {children}
     </div>
   );

--- a/packages/ui/src/components/Divider.tsx
+++ b/packages/ui/src/components/Divider.tsx
@@ -10,7 +10,7 @@ export function Divider({ label, className = "" }: DividerProps) {
     return (
       <div className={["flex items-center gap-3", className].join(" ")}>
         <div className="flex-1 border-t border-surface-border" />
-        <span className="text-xs text-gray-400 uppercase tracking-wide">{label}</span>
+        <span className="text-xs text-slate-500 uppercase tracking-wide">{label}</span>
         <div className="flex-1 border-t border-surface-border" />
       </div>
     );

--- a/packages/ui/src/components/Divider.tsx
+++ b/packages/ui/src/components/Divider.tsx
@@ -9,12 +9,12 @@ export function Divider({ label, className = "" }: DividerProps) {
   if (label) {
     return (
       <div className={["flex items-center gap-3", className].join(" ")}>
-        <div className="flex-1 border-t border-gray-200" />
+        <div className="flex-1 border-t border-surface-border" />
         <span className="text-xs text-gray-400 uppercase tracking-wide">{label}</span>
-        <div className="flex-1 border-t border-gray-200" />
+        <div className="flex-1 border-t border-surface-border" />
       </div>
     );
   }
 
-  return <hr className={["border-t border-gray-200", className].join(" ")} />;
+  return <hr className={["border-t border-surface-border", className].join(" ")} />;
 }

--- a/packages/ui/src/components/Input.tsx
+++ b/packages/ui/src/components/Input.tsx
@@ -11,11 +11,12 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         ref={ref}
         className={[
           "w-full rounded-lg border px-3 py-2.5 text-sm transition-colors",
-          "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
-          "disabled:bg-gray-50 disabled:cursor-not-allowed",
+          "text-slate-200 placeholder:text-slate-500",
+          "focus:outline-none focus:ring-2 focus:ring-brand/50 focus:border-brand/50",
+          "disabled:bg-surface/50 disabled:cursor-not-allowed disabled:text-slate-500",
           error
-            ? "border-red-300 bg-red-50 focus:ring-red-400"
-            : "border-gray-300 bg-white",
+            ? "border-red-500/50 bg-red-500/10 focus:ring-red-400/50"
+            : "border-surface-border bg-surface",
           className,
         ].join(" ")}
         {...props}

--- a/packages/ui/src/components/Label.tsx
+++ b/packages/ui/src/components/Label.tsx
@@ -7,7 +7,7 @@ interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
 export function Label({ required, className = "", children, ...props }: LabelProps) {
   return (
     <label
-      className={["block text-sm font-medium text-gray-700 mb-1", className].join(" ")}
+      className={["block text-sm font-medium text-slate-300 mb-1", className].join(" ")}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Resumen

Implementación de la issue #10 — rediseño visual completo al dark theme inspirado en la estética de marketplaces TCG premium.

## Cambios realizados

- **`tailwind.config.ts`**: paleta completa reemplazada — dark navy (`#0d1525`), gold (`#f0a500`), naranja (`#e85d04`), tokens `surface`, `bg`, `rarity` y `condition` adaptados al tema oscuro
- **`globals.css`**: fondo base oscuro en body, scrollbar personalizada con thumb dorado
- **`Button`**: variantes `primary` (naranja+glow), `brand` (dorado), `secondary`/`ghost` sobre fondo oscuro
- **`Card`**: superficie `surface` oscura, borde sutil, hover con `glow-card`
- **`Badge`**: variantes dark con opacidad (`success`, `warning`, `danger`, `info`, `gold`)
- **`Alert`, `Input`, `Label`, `Divider`**: adaptados a tema oscuro
- **`Navbar`**: fondo semitransparente + blur, logo dorado, underline naranja en link activo
- **`Footer`**: fondo `bg-deep`, links hover dorados
- **`page.tsx`**: hero con gradiente oscuro + glow decorativo radial, CTAs naranja y secondary
- **`CardListingCard`**: superficie oscura, precio en blanco bold, hover con glow + elevación sutil

## Criterios de aceptación
- [x] `tailwind.config.ts`: paleta dark navy + gold + naranja + tokens `surface`/`bg`
- [x] `globals.css`: fondo oscuro base y scrollbar personalizada
- [x] `Button`: variantes primary naranja, brand dorada, secondary sobre fondo oscuro
- [x] `Card`: fondo oscuro con borde sutil y hover glow
- [x] `Badge`: variantes dark con opacidad
- [x] `Navbar`: fondo oscuro, logo dorado, underline naranja activo
- [x] `Footer`: fondo más oscuro que body
- [x] Hero: gradiente oscuro, h1 blanco/gold, CTAs naranja
- [x] `CardListingCard`: borde oscuro, precio blanco bold, hover glow
- [x] Sin errores TypeScript nuevos (los pre-existentes en `auth.ts` no son de esta PR)

## Cómo probar

1. `pnpm dev` desde la raíz
2. http://localhost:3000 — fondo navy oscuro, hero con glow, CTAs naranja
3. http://localhost:3000/listings — cards oscuras con hover glow
4. http://localhost:3000/login — formulario con inputs y labels dark
5. Navbar logo dorado, links con underline naranja en ruta activa

Closes #10

🤖 Implementado con [Claude Code](https://claude.com/claude-code)