### PR TITLE
feat(home): rediseñar home como centro operativo del marketplace

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,22 +1,35 @@
 import Link from "next/link";
+import type { Metadata } from "next";
 import { Button, Badge } from "@cardbuy/ui";
+import { auth } from "@/lib/auth";
+import { SearchBar } from "@/components/home/SearchBar";
+import { GamesGrid } from "@/components/home/GamesGrid";
+import { RecentListings } from "@/components/home/RecentListings";
+import { TrendingSection } from "@/components/home/TrendingSection";
 
-const GAMES = [
-  { name: "Pokémon", href: "/listings?game=pokemon", emoji: "🔴" },
-  { name: "Magic: The Gathering", href: "/listings?game=magic", emoji: "🟣" },
-  { name: "Yu-Gi-Oh!", href: "/listings?game=yugioh", emoji: "🟡" },
-  { name: "One Piece", href: "/listings?game=onepiece", emoji: "🔵" },
-  { name: "Lorcana", href: "/listings?game=lorcana", emoji: "🟢" },
-  { name: "Dragon Ball", href: "/listings?game=dragonball", emoji: "🟠" },
-];
+export const metadata: Metadata = {
+  title: "CardBuy — Marketplace TCG de confianza",
+  description:
+    "Compra y vende cartas TCG con seguridad. Vendedores verificados, pago protegido y gestión de disputas. Pokémon, Magic: The Gathering, Yu-Gi-Oh! y más.",
+  openGraph: {
+    title: "CardBuy — Marketplace TCG de confianza",
+    description:
+      "Compra y vende cartas TCG con seguridad. Vendedores verificados, pago protegido y gestión de disputas.",
+    type: "website",
+    locale: "es_ES",
+    siteName: "CardBuy",
+  },
+};
 
-export default function HomePage() {
+export default async function HomePage() {
+  const session = await auth();
+
   return (
     <>
       {/* Hero */}
-      <section className="relative bg-hero-gradient py-24 px-4 overflow-hidden">
+      <section className="relative bg-hero-gradient py-20 px-4 overflow-hidden">
         {/* Glow decorativo */}
-        <div className="absolute inset-0 pointer-events-none">
+        <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] bg-brand/5 rounded-full blur-3xl" />
           <div className="absolute top-1/2 right-1/4 w-[300px] h-[300px] bg-accent/5 rounded-full blur-3xl" />
         </div>
@@ -29,60 +42,109 @@ export default function HomePage() {
             Compra y vende cartas TCG{" "}
             <span className="text-brand">con seguridad</span>
           </h1>
-          <p className="mt-6 text-lg text-slate-400 max-w-2xl mx-auto">
+          <p className="mt-4 text-lg text-slate-400 max-w-2xl mx-auto">
             Vendedores verificados, pago protegido y gestión de disputas. El marketplace
             para coleccionistas y jugadores de Pokémon, Magic, Yu-Gi-Oh! y más.
           </p>
-          <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-            <Link href="/listings">
-              <Button variant="primary" size="lg">Ver cartas en venta</Button>
-            </Link>
-            <Link href="/register">
-              <Button variant="secondary" size="lg">
-                Vender mis cartas
-              </Button>
-            </Link>
+
+          {/* Barra de búsqueda global */}
+          <div className="mt-8 flex justify-center">
+            <SearchBar />
+          </div>
+
+          {/* CTAs diferenciados según estado de autenticación */}
+          <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            {session ? (
+              <>
+                <Link href="/orders">
+                  <Button variant="primary" size="lg">Mis compras</Button>
+                </Link>
+                <Link href="/seller/dashboard">
+                  <Button variant="secondary" size="lg">Mis ventas</Button>
+                </Link>
+              </>
+            ) : (
+              <>
+                <Link href="/listings">
+                  <Button variant="primary" size="lg">Ver cartas en venta</Button>
+                </Link>
+                <Link href="/register">
+                  <Button variant="secondary" size="lg">Vender mis cartas</Button>
+                </Link>
+              </>
+            )}
           </div>
         </div>
       </section>
 
-      {/* Juegos */}
-      <section className="py-16 px-4">
+      {/* Explora por juego */}
+      <section className="py-14 px-4">
         <div className="mx-auto max-w-7xl">
-          <h2 className="font-display text-2xl font-bold text-white text-center mb-10">
+          <h2 className="font-display text-xl font-bold text-white text-center mb-8">
             Explora por juego
           </h2>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
-            {GAMES.map((game) => (
-              <Link
-                key={game.href}
-                href={game.href}
-                className="flex flex-col items-center gap-2 rounded-xl border border-surface-border bg-surface p-4 text-center transition-all duration-200 hover:border-brand/40 hover:bg-surface-hover hover:shadow-glow-card"
-              >
-                <span className="text-3xl">{game.emoji}</span>
-                <span className="text-sm font-medium text-slate-300 group-hover:text-white">{game.name}</span>
-              </Link>
-            ))}
+          <GamesGrid />
+        </div>
+      </section>
+
+      {/* Recién publicadas */}
+      <section className="py-14 px-4 border-t border-surface-border">
+        <div className="mx-auto max-w-7xl">
+          <div className="flex items-center justify-between mb-8">
+            <h2 className="font-display text-xl font-bold text-white">
+              Recién publicadas
+            </h2>
+            <Link
+              href="/listings"
+              className="text-sm text-brand hover:text-brand-light transition-colors"
+            >
+              Ver todas →
+            </Link>
           </div>
+          <RecentListings />
+        </div>
+      </section>
+
+      {/* En tendencia */}
+      <section className="py-14 px-4 border-t border-surface-border">
+        <div className="mx-auto max-w-7xl">
+          <div className="flex items-center justify-between mb-8">
+            <h2 className="font-display text-xl font-bold text-white">
+              En tendencia
+            </h2>
+            <Link
+              href="/listings"
+              className="text-sm text-brand hover:text-brand-light transition-colors"
+            >
+              Ver más →
+            </Link>
+          </div>
+          <TrendingSection />
         </div>
       </section>
 
       {/* Trust signals */}
-      <section className="py-16 px-4 border-t border-surface-border">
+      <section className="py-14 px-4 border-t border-surface-border">
         <div className="mx-auto max-w-7xl">
           <div className="grid grid-cols-1 gap-8 sm:grid-cols-3 text-center">
             <div className="flex flex-col items-center gap-3">
-              <div className="w-12 h-12 rounded-full bg-brand/15 flex items-center justify-center text-2xl">✓</div>
+              <div className="w-12 h-12 rounded-full bg-brand/15 flex items-center justify-center text-2xl">
+                ✓
+              </div>
               <h3 className="font-semibold text-white">Vendedores verificados</h3>
               <p className="text-sm text-slate-500">KYC obligatorio para todos los vendedores</p>
             </div>
             <div className="flex flex-col items-center gap-3">
-              <div className="w-12 h-12 rounded-full bg-accent/15 flex items-center justify-center text-2xl">🔒</div>
+              <div className="w-12 h-12 rounded-full bg-accent/15 flex items-center justify-center text-2xl">
+                🔒
+              </div>
               <h3 className="font-semibold text-white">Pago protegido</h3>
               <p className="text-sm text-slate-500">El dinero se libera al confirmar la recepción</p>
             </div>
             <div className="flex flex-col items-center gap-3">
-              <div className="w-12 h-12 rounded-full bg-brand/15 flex items-center justify-center text-2xl">⭐</div>
+              <div className="w-12 h-12 rounded-full bg-brand/15 flex items-center justify-center text-2xl">
+                ⭐
+              </div>
               <h3 className="font-semibold text-white">Sistema de reputación</h3>
               <p className="text-sm text-slate-500">Valoraciones verificadas de compradores reales</p>
             </div>

--- a/apps/web/src/components/home/GamesGrid.tsx
+++ b/apps/web/src/components/home/GamesGrid.tsx
@@ -1,0 +1,103 @@
+import Link from "next/link";
+
+const GAMES = [
+  {
+    name: "Pokémon",
+    href: "/listings?game=pokemon",
+    gradient: "from-red-900/50 to-yellow-900/30",
+    border: "hover:border-red-500/50",
+    icon: "⚡",
+    color: "text-red-400",
+  },
+  {
+    name: "Magic: The Gathering",
+    href: "/listings?game=magic",
+    gradient: "from-purple-900/50 to-blue-900/30",
+    border: "hover:border-purple-500/50",
+    icon: "✦",
+    color: "text-purple-400",
+  },
+  {
+    name: "Yu-Gi-Oh!",
+    href: "/listings?game=yugioh",
+    gradient: "from-yellow-900/50 to-slate-900/30",
+    border: "hover:border-yellow-500/50",
+    icon: "★",
+    color: "text-yellow-400",
+  },
+  {
+    name: "One Piece",
+    href: "/listings?game=onepiece",
+    gradient: "from-blue-900/50 to-red-900/30",
+    border: "hover:border-blue-500/50",
+    icon: "☠",
+    color: "text-blue-400",
+  },
+  {
+    name: "Lorcana",
+    href: "/listings?game=lorcana",
+    gradient: "from-indigo-900/50 to-purple-900/30",
+    border: "hover:border-indigo-500/50",
+    icon: "✦",
+    color: "text-indigo-400",
+  },
+  {
+    name: "Dragon Ball",
+    href: "/listings?game=dragonball",
+    gradient: "from-orange-900/50 to-yellow-900/30",
+    border: "hover:border-orange-500/50",
+    icon: "◉",
+    color: "text-orange-400",
+  },
+  {
+    name: "Flesh and Blood",
+    href: "/listings?game=flesh-and-blood",
+    gradient: "from-red-950/60 to-slate-900/30",
+    border: "hover:border-red-400/50",
+    icon: "⚔",
+    color: "text-red-300",
+  },
+  {
+    name: "Digimon",
+    href: "/listings?game=digimon",
+    gradient: "from-cyan-900/50 to-blue-900/30",
+    border: "hover:border-cyan-500/50",
+    icon: "◈",
+    color: "text-cyan-400",
+  },
+  {
+    name: "Vanguard",
+    href: "/listings?game=vanguard",
+    gradient: "from-blue-900/50 to-slate-800/30",
+    border: "hover:border-blue-400/50",
+    icon: "◆",
+    color: "text-blue-300",
+  },
+];
+
+export function GamesGrid() {
+  return (
+    <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-9">
+      {GAMES.map((game) => (
+        <Link
+          key={game.href}
+          href={game.href}
+          className={[
+            "flex flex-col items-center gap-2 rounded-xl border border-surface-border",
+            `bg-gradient-to-br ${game.gradient}`,
+            "p-4 text-center transition-all duration-200",
+            game.border,
+            "hover:shadow-glow-card hover:-translate-y-0.5",
+          ].join(" ")}
+        >
+          <span className={`text-2xl font-bold leading-none ${game.color}`}>
+            {game.icon}
+          </span>
+          <span className="text-xs font-medium text-slate-300 leading-tight">
+            {game.name}
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/home/RecentListings.tsx
+++ b/apps/web/src/components/home/RecentListings.tsx
@@ -1,0 +1,25 @@
+import { CardListingCard, type CardListingData } from "@/components/listings/CardListingCard";
+
+// Placeholder listings — se sustituirá por fetch real desde packages/db en issue de marketplace
+const RECENT_LISTINGS: CardListingData[] = [];
+
+export function RecentListings() {
+  if (RECENT_LISTINGS.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center rounded-xl border border-dashed border-surface-border">
+        <span className="text-4xl mb-3">🃏</span>
+        <p className="text-sm text-slate-500">
+          Pronto aparecerán aquí las últimas cartas publicadas.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+      {RECENT_LISTINGS.map((listing) => (
+        <CardListingCard key={listing.id} listing={listing} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/home/SearchBar.tsx
+++ b/apps/web/src/components/home/SearchBar.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export function SearchBar() {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (trimmed) {
+      router.push(`/listings?q=${encodeURIComponent(trimmed)}`);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="relative w-full max-w-xl">
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Buscar carta, set o vendedor..."
+        className="w-full rounded-xl border border-surface-border bg-surface px-5 py-3.5 pr-24 text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-brand/50 focus:border-brand/50 transition-colors"
+      />
+      <button
+        type="submit"
+        className="absolute right-2 top-1/2 -translate-y-1/2 rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-bg hover:bg-brand-light transition-colors"
+      >
+        Buscar
+      </button>
+    </form>
+  );
+}

--- a/apps/web/src/components/home/TrendingSection.tsx
+++ b/apps/web/src/components/home/TrendingSection.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import { Badge } from "@cardbuy/ui";
+
+interface TrendingCard {
+  id: string;
+  name: string;
+  game: string;
+  gameLabel: string;
+  priceRange: string;
+  trend: "up" | "hot";
+  badgeVariant: "success" | "warning" | "danger" | "info" | "gold";
+}
+
+// Mock trending cards — se sustituirá por datos reales de PriceHistory/búsquedas en issue de pricing
+const TRENDING_CARDS: TrendingCard[] = [
+  { id: "1", name: "Charizard ex", game: "pokemon", gameLabel: "Pokémon", priceRange: "30–120 €", trend: "hot", badgeVariant: "danger" },
+  { id: "2", name: "Black Lotus", game: "magic", gameLabel: "Magic", priceRange: "800–5000 €", trend: "up", badgeVariant: "gold" },
+  { id: "3", name: "Blue-Eyes White Dragon", game: "yugioh", gameLabel: "Yu-Gi-Oh!", priceRange: "15–80 €", trend: "up", badgeVariant: "info" },
+  { id: "4", name: "Monkey D. Luffy", game: "onepiece", gameLabel: "One Piece", priceRange: "20–60 €", trend: "hot", badgeVariant: "danger" },
+  { id: "5", name: "Elsa — Spirit of Winter", game: "lorcana", gameLabel: "Lorcana", priceRange: "10–45 €", trend: "up", badgeVariant: "success" },
+  { id: "6", name: "Son Goku, Saiyan Raised on Earth", game: "dragonball", gameLabel: "Dragon Ball", priceRange: "8–30 €", trend: "up", badgeVariant: "warning" },
+];
+
+export function TrendingSection() {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+      {TRENDING_CARDS.map((card) => (
+        <Link
+          key={card.id}
+          href={`/listings?game=${card.game}&q=${encodeURIComponent(card.name)}`}
+          className="flex flex-col gap-2 rounded-xl border border-surface-border bg-surface p-4 transition-all duration-200 hover:border-brand/40 hover:bg-surface-hover hover:shadow-glow-card hover:-translate-y-0.5"
+        >
+          <div className="flex items-center justify-between gap-1">
+            <Badge variant={card.badgeVariant} className="text-[10px]">
+              {card.trend === "hot" ? "🔥 Hot" : "↑ Subiendo"}
+            </Badge>
+          </div>
+          <p className="text-sm font-medium text-slate-200 leading-tight line-clamp-2">
+            {card.name}
+          </p>
+          <div className="mt-auto space-y-1">
+            <p className="text-xs text-slate-500">{card.gameLabel}</p>
+            <p className="text-sm font-bold text-brand">{card.priceRange}</p>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Resumen

Transforma la home de landing page estática a centro operativo del marketplace. Añade búsqueda global, listings recientes, tendencias y CTAs diferenciados según estado de autenticación.

## Cambios realizados
- **`apps/web/src/app/page.tsx`** — reescrito como Server Component con `auth()` para CTAs contextuales y metadata OG completa
- **`components/home/SearchBar.tsx`** — barra de búsqueda global (client component) que redirige a `/listings?q=...`
- **`components/home/GamesGrid.tsx`** — grid de los 9 juegos con gradientes visuales únicos por juego
- **`components/home/RecentListings.tsx`** — sección de últimas publicaciones (placeholder listo para datos reales)
- **`components/home/TrendingSection.tsx`** — sección de tendencias con mock data (preparada para PriceHistory)

## Criterios de aceptación
- [x] Barra de búsqueda global en el hero que redirige a `/listings?q=...`
- [x] Sección "Recién publicadas" con las últimas CardListing activas (placeholder en v1)
- [x] Sección "Tendencias" con cartas más buscadas por juego (mock data en v1)
- [x] Grid de juegos ampliado a los 9 juegos soportados con estilos visuales
- [x] CTA diferenciado para usuarios autenticados vs no autenticados (SSR)
- [x] Metadata OG completa (`og:title`, `og:description`, `og:type`)
- [x] Layout responsive mobile-first sin scroll horizontal

## Cómo probar
1. `pnpm dev` desde la raíz del monorepo
2. Visitar `http://localhost:3000`
3. Escribir en la barra de búsqueda y verificar redirect a `/listings?q=...`
4. Con sesión activa: botones "Mis compras" / "Mis ventas" en el hero
5. Sin sesión: botones "Ver cartas en venta" / "Vender mis cartas"
6. Verificar los 9 juegos en el grid con sus gradientes de color
7. Comprobar en mobile (< 640px) que no hay scroll horizontal

Closes #12

🤖 Implementado con [Claude Code](https://claude.com/claude-code)