### PR TITLE
feat(navbar): búsqueda global persistente con expand mobile

### DIFF
--- a/apps/web/src/components/NavSearchBar.tsx
+++ b/apps/web/src/components/NavSearchBar.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect, useRef, useCallback, Suspense } from "react";
+
+function SearchIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.35-4.35" />
+    </svg>
+  );
+}
+
+function NavSearchBarInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [query, setQuery] = useState(searchParams.get("q") ?? "");
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const mobileInputRef = useRef<HTMLInputElement>(null);
+
+  // Sync input value when ?q= changes (e.g. navigating back/forward)
+  useEffect(() => {
+    setQuery(searchParams.get("q") ?? "");
+  }, [searchParams]);
+
+  // Auto-focus when mobile search opens
+  useEffect(() => {
+    if (mobileOpen) {
+      mobileInputRef.current?.focus();
+    }
+  }, [mobileOpen]);
+
+  // Close mobile search on Escape
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && mobileOpen) {
+        setMobileOpen(false);
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [mobileOpen]);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const trimmed = query.trim();
+      const params = new URLSearchParams();
+      if (trimmed) params.set("q", trimmed);
+      // Preserve active filters if already on /listings
+      const game = searchParams.get("game");
+      const condition = searchParams.get("condition");
+      const language = searchParams.get("language");
+      if (game) params.set("game", game);
+      if (condition) params.set("condition", condition);
+      if (language) params.set("language", language);
+      router.push(`/listings?${params.toString()}`);
+      setMobileOpen(false);
+    },
+    [query, searchParams, router]
+  );
+
+  const desktopInput = (
+    <form
+      role="search"
+      aria-label="Búsqueda de cartas"
+      onSubmit={handleSubmit}
+      className="relative flex items-center"
+    >
+      <input
+        ref={inputRef}
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Buscar carta, set..."
+        className={[
+          "w-48 lg:w-64 rounded-lg border border-surface-border bg-surface",
+          "px-3 py-1.5 pr-8 text-sm text-slate-200 placeholder:text-slate-500",
+          "focus:outline-none focus:ring-2 focus:ring-brand/50 focus:border-brand/50",
+          "transition-all duration-200",
+        ].join(" ")}
+      />
+      <button
+        type="submit"
+        aria-label="Buscar"
+        className="absolute right-2 text-slate-400 hover:text-brand transition-colors"
+      >
+        <SearchIcon />
+      </button>
+    </form>
+  );
+
+  return (
+    <>
+      {/* Desktop — inline en la navbar */}
+      <div className="hidden md:block">{desktopInput}</div>
+
+      {/* Mobile — icono que despliega overlay */}
+      <div className="md:hidden">
+        <button
+          type="button"
+          aria-label="Abrir búsqueda"
+          onClick={() => setMobileOpen(true)}
+          className="p-2 rounded-lg text-slate-400 hover:text-white hover:bg-surface transition-colors"
+        >
+          <SearchIcon />
+        </button>
+
+        {mobileOpen && (
+          <div className="fixed inset-x-0 top-0 z-[60] bg-bg/95 backdrop-blur-md border-b border-surface-border px-4 py-3 flex items-center gap-3">
+            <form
+              role="search"
+              aria-label="Búsqueda de cartas"
+              onSubmit={handleSubmit}
+              className="flex-1 relative"
+            >
+              <input
+                ref={mobileInputRef}
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Buscar carta, set o vendedor..."
+                className={[
+                  "w-full rounded-lg border border-surface-border bg-surface",
+                  "px-4 py-2.5 pr-10 text-sm text-slate-200 placeholder:text-slate-500",
+                  "focus:outline-none focus:ring-2 focus:ring-brand/50 focus:border-brand/50",
+                  "transition-colors",
+                ].join(" ")}
+              />
+              <button
+                type="submit"
+                aria-label="Buscar"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-brand transition-colors"
+              >
+                <SearchIcon />
+              </button>
+            </form>
+            <button
+              type="button"
+              aria-label="Cerrar búsqueda"
+              onClick={() => setMobileOpen(false)}
+              className="shrink-0 p-1 text-slate-400 hover:text-white transition-colors"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M18 6 6 18M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+// Wrapped in Suspense because useSearchParams() requires it in App Router
+export function NavSearchBar() {
+  return (
+    <Suspense fallback={
+      <div className="hidden md:block w-48 lg:w-64 h-8 rounded-lg bg-surface animate-pulse" />
+    }>
+      <NavSearchBarInner />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useSession, signOut } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import { Button } from "@cardbuy/ui";
+import { NavSearchBar } from "@/components/NavSearchBar";
 
 const NAV_LINKS = [
   { label: "Cartas", href: "/listings" },
@@ -19,24 +20,26 @@ export function Navbar() {
   return (
     <nav className="sticky top-0 z-50 border-b border-surface-border bg-bg/90 backdrop-blur-md">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex h-16 items-center justify-between">
+        <div className="flex h-16 items-center gap-4">
           {/* Logo */}
-          <Link href="/" className="flex items-center gap-2 group">
+          <Link href="/" className="flex items-center gap-2 group shrink-0">
             <span className="font-display text-xl font-bold text-brand group-hover:text-brand-light transition-colors">
               CardBuy
             </span>
           </Link>
 
-          {/* Links principales */}
+          {/* Links principales — solo desktop */}
           <div className="hidden items-center gap-1 md:flex">
             {NAV_LINKS.map((link) => {
-              const isActive = pathname === link.href || pathname?.startsWith(link.href.split("?")[0]);
+              const isActive =
+                pathname === link.href ||
+                pathname?.startsWith(link.href.split("?")[0]);
               return (
                 <Link
                   key={link.href}
                   href={link.href}
                   className={[
-                    "px-3 py-1.5 text-sm font-medium rounded-md transition-colors relative",
+                    "px-3 py-1.5 text-sm font-medium rounded-md transition-colors relative whitespace-nowrap",
                     isActive
                       ? "text-white after:absolute after:bottom-0 after:left-3 after:right-3 after:h-0.5 after:bg-accent after:rounded-full"
                       : "text-slate-400 hover:text-white hover:bg-surface",
@@ -48,11 +51,16 @@ export function Navbar() {
             })}
           </div>
 
+          {/* Búsqueda — crece para ocupar espacio disponible */}
+          <div className="flex-1 flex justify-center md:justify-start">
+            <NavSearchBar />
+          </div>
+
           {/* Auth */}
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 shrink-0">
             {status === "loading" ? null : session ? (
               <>
-                <span className="hidden text-sm text-slate-400 sm:block">
+                <span className="hidden text-sm text-slate-400 lg:block truncate max-w-[120px]">
                   {session.user?.name ?? session.user?.email}
                 </span>
                 <Button
@@ -71,7 +79,9 @@ export function Navbar() {
                   </Button>
                 </Link>
                 <Link href="/register">
-                  <Button variant="primary" size="sm">Registrarse</Button>
+                  <Button variant="primary" size="sm">
+                    Registrarse
+                  </Button>
                 </Link>
               </>
             )}

--- a/apps/web/src/components/home/SearchBar.tsx
+++ b/apps/web/src/components/home/SearchBar.tsx
@@ -1,28 +1,46 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect, useCallback, Suspense } from "react";
 
-export function SearchBar() {
+function HeroSearchBarInner() {
   const router = useRouter();
-  const [query, setQuery] = useState("");
+  const searchParams = useSearchParams();
+  const [query, setQuery] = useState(searchParams.get("q") ?? "");
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    const trimmed = query.trim();
-    if (trimmed) {
-      router.push(`/listings?q=${encodeURIComponent(trimmed)}`);
-    }
-  }
+  useEffect(() => {
+    setQuery(searchParams.get("q") ?? "");
+  }, [searchParams]);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const trimmed = query.trim();
+      const params = new URLSearchParams();
+      if (trimmed) params.set("q", trimmed);
+      router.push(`/listings?${params.toString()}`);
+    },
+    [query, router]
+  );
 
   return (
-    <form onSubmit={handleSubmit} className="relative w-full max-w-xl">
+    <form
+      role="search"
+      aria-label="Búsqueda principal de cartas"
+      onSubmit={handleSubmit}
+      className="relative w-full max-w-xl"
+    >
       <input
         type="search"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Buscar carta, set o vendedor..."
-        className="w-full rounded-xl border border-surface-border bg-surface px-5 py-3.5 pr-24 text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-brand/50 focus:border-brand/50 transition-colors"
+        className={[
+          "w-full rounded-xl border border-surface-border bg-surface",
+          "px-5 py-3.5 pr-24 text-sm text-slate-200 placeholder:text-slate-500",
+          "focus:outline-none focus:ring-2 focus:ring-brand/50 focus:border-brand/50",
+          "transition-colors",
+        ].join(" ")}
       />
       <button
         type="submit"
@@ -31,5 +49,15 @@ export function SearchBar() {
         Buscar
       </button>
     </form>
+  );
+}
+
+export function SearchBar() {
+  return (
+    <Suspense fallback={
+      <div className="w-full max-w-xl h-[52px] rounded-xl bg-surface animate-pulse" />
+    }>
+      <HeroSearchBarInner />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Resumen

Eleva la búsqueda a elemento de primer nivel en la navbar: siempre visible en desktop, expand overlay en mobile. Sincronizada con la URL y con preservación de filtros activos.

## Cambios realizados
- **`components/NavSearchBar.tsx`** (nuevo) — componente de búsqueda para navbar: desktop inline + overlay mobile con Escape/auto-focus, sincroniza con `?q=`, preserva `game`/`condition`/`language`
- **`components/Navbar.tsx`** — integra `NavSearchBar` entre los nav links y el área de auth; layout ajustado a flexbox con `flex-1` para el área de búsqueda
- **`components/home/SearchBar.tsx`** — actualizado con `useSearchParams` + Suspense boundary; preserva consistencia con la navbar

## Criterios de aceptación
- [x] Barra de búsqueda en navbar en todas las páginas (desktop: inline, mobile: icono → overlay)
- [x] Navega a `/listings?q=...` preservando filtros activos (`game`, `condition`, `language`)
- [x] En `/listings`, el input refleja el `?q=` actual de la URL
- [x] Mobile: icono lupa que expande input full-width sobre la navbar
- [x] Auto-focus al abrir en mobile
- [x] Escape cierra el overlay mobile
- [x] Hero `SearchBar` reutiliza la misma lógica (Suspense + URL sync)
- [x] Accesibilidad: `role="search"`, `aria-label`, soporte teclado

## Cómo probar
1. `pnpm dev` — visitar cualquier página y verificar la lupa/input en la navbar
2. Desktop (≥ 768px): input visible inline, escribir y Enter → `/listings?q=...`
3. Mobile (< 768px): tap en lupa → overlay con input full-width; Escape lo cierra
4. Navegar a `/listings?game=pokemon`, buscar "Charizard" → URL resultante: `/listings?q=Charizard&game=pokemon`
5. Con `?q=pikachu` en la URL, navegar a otra página y volver — el input muestra "pikachu"

Closes #15

🤖 Implementado con [Claude Code](https://claude.com/claude-code)