### PR TITLE
feat: conectar catálogo y resultados de búsqueda con datos reales

### DIFF
--- a/.claude/commands/new-issue.md
+++ b/.claude/commands/new-issue.md
@@ -78,3 +78,86 @@ Después de la issue, añade una línea con:
 **Estimación sugerida:** [XS/S/M/L/XL] — [breve justificación en 1 línea]
 
 Sé preciso, operativo y adaptado al contexto TCG. Si la descripción original es vaga, infiere el contexto razonablemente y menciona qué asumiste.
+
+## Paso final — Crear issue en GitHub y añadir al Kanban
+
+### 1. Crear la issue
+
+```bash
+ISSUE_URL=$(gh issue create \
+  --repo juanmbarrios/cardbuy \
+  --title "<título sin el prefijo [Tipo]>" \
+  --label "<labels sugeridos separados por coma>" \
+  --body "<cuerpo completo de la issue en markdown>")
+echo "$ISSUE_URL"
+```
+
+### 2. Añadir al proyecto Kanban en columna "Todo"
+
+```bash
+# Leer PROJECT_NUMBER del .env
+PROJECT_NUMBER=$(grep -E "^PROJECT_NUMBER=" .env 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "1")
+
+# Añadir la issue al proyecto
+ITEM_JSON=$(gh project item-add "$PROJECT_NUMBER" --owner juanmbarrios --url "$ISSUE_URL" --format json 2>/dev/null)
+ITEM_ID=$(echo "$ITEM_JSON" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+# Obtener IDs del proyecto y del campo Status
+PROJECT_DATA=$(gh api graphql -f query='
+query($owner: String!, $number: Int!) {
+  user(login: $owner) {
+    projectV2(number: $number) {
+      id
+      fields(first: 20) {
+        nodes {
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            options { id name }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="juanmbarrios" -F number="$PROJECT_NUMBER" 2>/dev/null)
+
+PROJECT_ID=$(echo "$PROJECT_DATA" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+STATUS_FIELD_ID=$(echo "$PROJECT_DATA" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for f in d['data']['user']['projectV2']['fields']['nodes']:
+    if f.get('name') == 'Status':
+        print(f['id'])
+        break
+" 2>/dev/null)
+TODO_OPTION_ID=$(echo "$PROJECT_DATA" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for f in d['data']['user']['projectV2']['fields']['nodes']:
+    if f.get('name') == 'Status':
+        for o in f['options']:
+            if o['name'] == 'Todo':
+                print(o['id'])
+                break
+" 2>/dev/null)
+
+# Mover a columna Todo
+if [ -n "$ITEM_ID" ] && [ -n "$STATUS_FIELD_ID" ] && [ -n "$TODO_OPTION_ID" ]; then
+  gh project item-edit \
+    --id "$ITEM_ID" \
+    --field-id "$STATUS_FIELD_ID" \
+    --project-id "$PROJECT_ID" \
+    --single-select-option-id "$TODO_OPTION_ID" 2>/dev/null \
+    && echo "✓ Issue añadida al Kanban en columna Todo" \
+    || echo "⚠ No se pudo actualizar el Kanban (verifica PROJECT_NUMBER y permisos)"
+else
+  echo "⚠ No se pudo mover al Kanban — verifica PROJECT_NUMBER en .env y que gh tenga scope 'project'"
+fi
+```
+
+### 3. Mostrar al usuario
+
+Muestra:
+- La URL de la issue creada
+- El número de issue
+- Confirmación de que está en el Kanban (o aviso si falló)

--- a/apps/web/src/__tests__/listings-service.test.ts
+++ b/apps/web/src/__tests__/listings-service.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapGameToDb,
+  mapConditionToDb,
+  mapLanguageToDb,
+  mapDbToGame,
+  mapDbToCondition,
+  mapDbToLanguage,
+} from "@/lib/listings";
+import { Game, CardCondition, CardLanguage } from "@cardbuy/db";
+
+// ---------------------------------------------------------------------------
+// Tests — mapGameToDb
+// ---------------------------------------------------------------------------
+
+describe("mapGameToDb", () => {
+  it("maps 'pokemon' to Game.POKEMON", () => {
+    expect(mapGameToDb("pokemon")).toBe(Game.POKEMON);
+  });
+
+  it("maps 'magic' to Game.MAGIC_THE_GATHERING", () => {
+    expect(mapGameToDb("magic")).toBe(Game.MAGIC_THE_GATHERING);
+  });
+
+  it("maps 'mtg' alias to Game.MAGIC_THE_GATHERING", () => {
+    expect(mapGameToDb("mtg")).toBe(Game.MAGIC_THE_GATHERING);
+  });
+
+  it("maps 'yugioh' to Game.YUGIOH", () => {
+    expect(mapGameToDb("yugioh")).toBe(Game.YUGIOH);
+  });
+
+  it("maps 'onepiece' to Game.ONE_PIECE", () => {
+    expect(mapGameToDb("onepiece")).toBe(Game.ONE_PIECE);
+  });
+
+  it("maps 'flesh-and-blood' to Game.FLESH_AND_BLOOD", () => {
+    expect(mapGameToDb("flesh-and-blood")).toBe(Game.FLESH_AND_BLOOD);
+  });
+
+  it("maps 'fab' alias to Game.FLESH_AND_BLOOD", () => {
+    expect(mapGameToDb("fab")).toBe(Game.FLESH_AND_BLOOD);
+  });
+
+  it("returns undefined for unknown game", () => {
+    expect(mapGameToDb("unknown-game")).toBeUndefined();
+  });
+
+  it("is case-insensitive", () => {
+    expect(mapGameToDb("POKEMON")).toBe(Game.POKEMON);
+    expect(mapGameToDb("Magic")).toBe(Game.MAGIC_THE_GATHERING);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — mapDbToGame (reverse)
+// ---------------------------------------------------------------------------
+
+describe("mapDbToGame", () => {
+  it("maps Game.POKEMON back to 'pokemon'", () => {
+    expect(mapDbToGame(Game.POKEMON)).toBe("pokemon");
+  });
+
+  it("maps Game.MAGIC_THE_GATHERING back to 'magic'", () => {
+    expect(mapDbToGame(Game.MAGIC_THE_GATHERING)).toBe("magic");
+  });
+
+  it("maps Game.ONE_PIECE back to 'onepiece'", () => {
+    expect(mapDbToGame(Game.ONE_PIECE)).toBe("onepiece");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — mapConditionToDb
+// ---------------------------------------------------------------------------
+
+describe("mapConditionToDb", () => {
+  it("maps 'NM' to NEAR_MINT", () => {
+    expect(mapConditionToDb("NM")).toBe(CardCondition.NEAR_MINT);
+  });
+
+  it("maps 'LP' to LIGHTLY_PLAYED", () => {
+    expect(mapConditionToDb("LP")).toBe(CardCondition.LIGHTLY_PLAYED);
+  });
+
+  it("maps 'MP' to MODERATELY_PLAYED", () => {
+    expect(mapConditionToDb("MP")).toBe(CardCondition.MODERATELY_PLAYED);
+  });
+
+  it("maps 'HP' to HEAVILY_PLAYED", () => {
+    expect(mapConditionToDb("HP")).toBe(CardCondition.HEAVILY_PLAYED);
+  });
+
+  it("maps 'DMG' to DAMAGED", () => {
+    expect(mapConditionToDb("DMG")).toBe(CardCondition.DAMAGED);
+  });
+
+  it("is case-insensitive", () => {
+    expect(mapConditionToDb("nm")).toBe(CardCondition.NEAR_MINT);
+    expect(mapConditionToDb("lp")).toBe(CardCondition.LIGHTLY_PLAYED);
+  });
+
+  it("returns undefined for unknown condition", () => {
+    expect(mapConditionToDb("EXCELLENT")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — mapDbToCondition (reverse)
+// ---------------------------------------------------------------------------
+
+describe("mapDbToCondition", () => {
+  it("maps NEAR_MINT back to 'NM'", () => {
+    expect(mapDbToCondition(CardCondition.NEAR_MINT)).toBe("NM");
+  });
+
+  it("maps DAMAGED back to 'DMG'", () => {
+    expect(mapDbToCondition(CardCondition.DAMAGED)).toBe("DMG");
+  });
+
+  it("round-trips for all conditions", () => {
+    const conditions = ["NM", "LP", "MP", "HP", "DMG"];
+    for (const c of conditions) {
+      const dbVal = mapConditionToDb(c);
+      expect(dbVal).toBeDefined();
+      expect(mapDbToCondition(dbVal!)).toBe(c);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — mapLanguageToDb
+// ---------------------------------------------------------------------------
+
+describe("mapLanguageToDb", () => {
+  it("maps 'EN' to CardLanguage.EN", () => {
+    expect(mapLanguageToDb("EN")).toBe(CardLanguage.EN);
+  });
+
+  it("maps 'ES' to CardLanguage.ES", () => {
+    expect(mapLanguageToDb("ES")).toBe(CardLanguage.ES);
+  });
+
+  it("maps UI 'JP' to DB CardLanguage.JA", () => {
+    expect(mapLanguageToDb("JP")).toBe(CardLanguage.JA);
+  });
+
+  it("maps 'JA' directly to CardLanguage.JA", () => {
+    expect(mapLanguageToDb("JA")).toBe(CardLanguage.JA);
+  });
+
+  it("is case-insensitive", () => {
+    expect(mapLanguageToDb("en")).toBe(CardLanguage.EN);
+    expect(mapLanguageToDb("jp")).toBe(CardLanguage.JA);
+  });
+
+  it("returns undefined for unknown language", () => {
+    expect(mapLanguageToDb("XX")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — mapDbToLanguage (reverse) — JA → JP (UI convention)
+// ---------------------------------------------------------------------------
+
+describe("mapDbToLanguage", () => {
+  it("maps CardLanguage.EN back to 'EN'", () => {
+    expect(mapDbToLanguage(CardLanguage.EN)).toBe("EN");
+  });
+
+  it("maps CardLanguage.JA back to 'JP' (UI convention)", () => {
+    expect(mapDbToLanguage(CardLanguage.JA)).toBe("JP");
+  });
+
+  it("round-trips for all supported UI languages (except JA→JP asymmetry)", () => {
+    const langs = ["EN", "ES", "FR", "DE", "IT", "PT"];
+    for (const l of langs) {
+      const dbVal = mapLanguageToDb(l);
+      expect(dbVal).toBeDefined();
+      expect(mapDbToLanguage(dbVal!)).toBe(l);
+    }
+  });
+});

--- a/apps/web/src/app/api/listings/[id]/route.ts
+++ b/apps/web/src/app/api/listings/[id]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getListingById } from "@/lib/listings";
+
+interface Params {
+  params: { id: string };
+}
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { id } = params;
+
+  try {
+    const listing = await getListingById(id);
+
+    if (!listing) {
+      return NextResponse.json(
+        { error: "Listing no encontrado" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(listing);
+  } catch (error) {
+    console.error(`[GET /api/listings/${id}]`, error);
+    return NextResponse.json(
+      { error: "Error al obtener el listing" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/listings/route.ts
+++ b/apps/web/src/app/api/listings/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getListings } from "@/lib/listings";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+
+  const pageRaw  = searchParams.get("page");
+  const limitRaw = searchParams.get("limit");
+  const sortRaw  = searchParams.get("sort");
+
+  const validSorts = ["price_asc", "price_desc", "newest"] as const;
+  type ValidSort = (typeof validSorts)[number];
+  const sort = validSorts.includes(sortRaw as ValidSort)
+    ? (sortRaw as ValidSort)
+    : undefined;
+
+  try {
+    const result = await getListings({
+      game:             searchParams.get("game")      ?? undefined,
+      condition:        searchParams.get("condition") ?? undefined,
+      language:         searchParams.get("language")  ?? undefined,
+      minPrice:         searchParams.get("minPrice")  ?? undefined,
+      maxPrice:         searchParams.get("maxPrice")  ?? undefined,
+      sort,
+      page:  pageRaw  ? Math.max(1, parseInt(pageRaw,  10)) : undefined,
+      limit: limitRaw ? Math.max(1, parseInt(limitRaw, 10)) : undefined,
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("[GET /api/listings]", error);
+    return NextResponse.json(
+      { error: "Error al obtener los listings" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/listings/[id]/page.tsx
+++ b/apps/web/src/app/listings/[id]/page.tsx
@@ -1,0 +1,243 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Badge, Button } from "@cardbuy/ui";
+import type { ListingDetail } from "@/lib/listings";
+
+// ---------------------------------------------------------------------------
+// Condition / language display maps (mirrors CardListingCard)
+// ---------------------------------------------------------------------------
+
+const CONDITION_LABELS: Record<string, string> = {
+  NM: "Near Mint",
+  LP: "Lightly Played",
+  MP: "Moderately Played",
+  HP: "Heavily Played",
+  DMG: "Damaged",
+};
+
+const CONDITION_VARIANTS: Record<string, "success" | "warning" | "danger" | "default"> = {
+  NM: "success",
+  LP: "success",
+  MP: "warning",
+  HP: "danger",
+  DMG: "danger",
+};
+
+const GAME_LABELS: Record<string, string> = {
+  pokemon:          "Pokémon",
+  magic:            "Magic: The Gathering",
+  yugioh:           "Yu-Gi-Oh!",
+  onepiece:         "One Piece",
+  lorcana:          "Lorcana",
+  dragonball:       "Dragon Ball",
+  "flesh-and-blood": "Flesh and Blood",
+  digimon:          "Digimon",
+  vanguard:         "Vanguard",
+};
+
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
+
+async function fetchListing(id: string): Promise<ListingDetail | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+
+  try {
+    const res = await fetch(`${baseUrl}/api/listings/${id}`, {
+      cache: "no-store",
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json() as Promise<ListingDetail>;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+interface Props {
+  params: { id: string };
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const listing = await fetchListing(params.id);
+  if (!listing) return { title: "Carta no encontrada" };
+  return {
+    title: `${listing.title} — CardBuy`,
+    description: `Compra ${listing.title} por ${listing.price.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}. Vendedor: ${listing.sellerName}.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default async function ListingDetailPage({ params }: Props) {
+  const listing = await fetchListing(params.id);
+
+  if (!listing) notFound();
+
+  const isOutOfStock = listing.stock === 0;
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-8">
+      {/* Breadcrumb */}
+      <nav className="mb-6 flex items-center gap-2 text-sm text-slate-400">
+        <Link href="/listings" className="hover:text-white transition-colors">
+          Cartas
+        </Link>
+        <span>/</span>
+        {listing.setName && (
+          <>
+            <span className="text-slate-500">{listing.setName}</span>
+            <span>/</span>
+          </>
+        )}
+        <span className="text-slate-300 truncate max-w-[240px]">{listing.title}</span>
+      </nav>
+
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+        {/* Imagen */}
+        <div className="flex items-start justify-center">
+          <div className="relative w-full max-w-xs aspect-[3/4] rounded-2xl overflow-hidden bg-bg-deep border border-surface-border">
+            {listing.imageUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={listing.imageUrl}
+                alt={listing.title}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center text-7xl text-slate-700">
+                🃏
+              </div>
+            )}
+            {isOutOfStock && (
+              <div className="absolute inset-0 bg-bg-deep/70 flex items-center justify-center">
+                <span className="text-sm font-semibold text-slate-400 uppercase tracking-widest">
+                  Agotado
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Detalle */}
+        <div className="flex flex-col gap-5">
+          {/* Juego + set */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-xs font-medium uppercase tracking-wider text-slate-500">
+              {GAME_LABELS[listing.game] ?? listing.game}
+            </span>
+            {listing.setName && (
+              <span className="text-xs text-slate-600">· {listing.setName}</span>
+            )}
+          </div>
+
+          {/* Título */}
+          <h1 className="font-display text-2xl font-bold text-white leading-tight">
+            {listing.title}
+          </h1>
+
+          {/* Precio */}
+          <div className="flex items-baseline gap-3 flex-wrap">
+            <span
+              className={[
+                "text-4xl font-bold leading-none",
+                isOutOfStock ? "text-slate-500" : "text-brand",
+              ].join(" ")}
+            >
+              {listing.price.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+            </span>
+            {listing.stock === 1 && <Badge variant="warning">Última unidad</Badge>}
+            {listing.stock > 1 && <Badge variant="success">En stock ({listing.stock})</Badge>}
+            {isOutOfStock && <Badge variant="danger">Agotado</Badge>}
+          </div>
+
+          {/* Condición, idioma, foil */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge variant={CONDITION_VARIANTS[listing.condition] ?? "default"}>
+              {CONDITION_LABELS[listing.condition] ?? listing.condition}
+            </Badge>
+            <Badge variant="outline">{listing.language}</Badge>
+            {listing.isFoil && <Badge variant="default">Foil</Badge>}
+            {listing.isGraded && <Badge variant="default">Gradada</Badge>}
+          </div>
+
+          {/* Descripción */}
+          {listing.description && (
+            <p className="text-sm text-slate-300 leading-relaxed">{listing.description}</p>
+          )}
+
+          {/* Vendedor */}
+          <div className="rounded-xl border border-surface-border bg-surface p-4 flex items-center gap-4">
+            <div className="h-10 w-10 rounded-full bg-surface-raised flex items-center justify-center text-slate-400 font-bold text-sm shrink-0">
+              {listing.sellerName.charAt(0).toUpperCase()}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-1.5">
+                <span className="text-sm font-medium text-white">{listing.sellerName}</span>
+                {listing.isVerified && (
+                  <span
+                    title="Vendedor verificado"
+                    className="text-brand text-xs font-bold leading-none"
+                  >
+                    ✓
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-1 mt-0.5">
+                <span className="text-amber-400 text-xs">★</span>
+                <span className="text-xs text-white font-medium">
+                  {listing.sellerRating.toFixed(1)}
+                </span>
+                <span className="text-xs text-slate-500">
+                  ({listing.sellerReviewCount} valoraciones)
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Envío */}
+          <div className="text-sm text-slate-400">
+            {listing.freeShipping ? (
+              <span className="text-green-400 font-medium">Envío gratuito</span>
+            ) : (
+              <span>
+                Envío:{" "}
+                {listing.shippingCost.toLocaleString("es-ES", {
+                  style: "currency",
+                  currency: "EUR",
+                })}
+              </span>
+            )}
+            <span className="ml-2 text-slate-600">
+              · Entrega en {listing.shippingDays} días hábiles
+            </span>
+          </div>
+
+          {/* CTA */}
+          <div className="flex flex-col gap-2">
+            <Button
+              variant="primary"
+              size="lg"
+              disabled={isOutOfStock}
+              className="w-full"
+            >
+              {isOutOfStock ? "No disponible" : "Añadir al carrito"}
+            </Button>
+            {!isOutOfStock && (
+              <p className="text-xs text-center text-slate-500">
+                Pago protegido · Devoluciones en 14 días
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/listings/page.tsx
+++ b/apps/web/src/app/listings/page.tsx
@@ -1,9 +1,10 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Spinner } from "@cardbuy/ui";
 import { FilterPanel } from "@/components/listings/FilterPanel";
 import { ListingsGrid } from "@/components/listings/ListingsGrid";
-import type { CardListingData } from "@/components/listings/CardListingCard";
+import { ListingsGridSkeleton } from "@/components/listings/ListingsGridSkeleton";
+import { ErrorState } from "@/components/ui/ErrorState";
+import type { PaginatedListings } from "@/lib/listings";
 
 interface SearchParams {
   game?: string;
@@ -13,6 +14,7 @@ interface SearchParams {
   maxPrice?: string;
   sort?: string;
   page?: string;
+  q?: string;
 }
 
 interface Props {
@@ -27,24 +29,62 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   };
 }
 
-// Placeholder listings — se sustituirá por fetch real en la issue de marketplace
-const PLACEHOLDER_LISTINGS: CardListingData[] = [];
+async function fetchListings(searchParams: SearchParams): Promise<PaginatedListings | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+  const params = new URLSearchParams();
 
-export default function ListingsPage({ searchParams }: Props) {
+  if (searchParams.game)      params.set("game",      searchParams.game);
+  if (searchParams.condition) params.set("condition", searchParams.condition);
+  if (searchParams.language)  params.set("language",  searchParams.language);
+  if (searchParams.minPrice)  params.set("minPrice",  searchParams.minPrice);
+  if (searchParams.maxPrice)  params.set("maxPrice",  searchParams.maxPrice);
+  if (searchParams.sort)      params.set("sort",      searchParams.sort);
+  if (searchParams.page)      params.set("page",      searchParams.page);
+
+  try {
+    const res = await fetch(`${baseUrl}/api/listings?${params.toString()}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    return res.json() as Promise<PaginatedListings>;
+  } catch {
+    return null;
+  }
+}
+
+async function ListingsSection({ searchParams }: { searchParams: SearchParams }) {
+  const data = await fetchListings(searchParams);
+
+  if (!data) {
+    return (
+      <ErrorState
+        title="No se pudo cargar el catálogo"
+        description="Ocurrió un error al conectar con el servidor. Inténtalo de nuevo."
+      />
+    );
+  }
+
   const gameLabel = searchParams.game
     ? searchParams.game.charAt(0).toUpperCase() + searchParams.game.slice(1)
     : "Todos los juegos";
 
   return (
-    <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
+    <>
       <div className="mb-6">
         <h1 className="font-display text-2xl font-bold text-white">{gameLabel}</h1>
         <p className="text-sm text-slate-400 mt-1">
-          {PLACEHOLDER_LISTINGS.length} carta{PLACEHOLDER_LISTINGS.length !== 1 ? "s" : ""} disponible
-          {PLACEHOLDER_LISTINGS.length !== 1 ? "s" : ""}
+          {data.total} carta{data.total !== 1 ? "s" : ""} disponible
+          {data.total !== 1 ? "s" : ""}
         </p>
       </div>
+      <ListingsGrid listings={data.listings} searchQuery={searchParams.q} />
+    </>
+  );
+}
 
+export default function ListingsPage({ searchParams }: Props) {
+  return (
+    <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
       <div className="flex flex-col gap-8 lg:flex-row">
         {/* Filtros */}
         <div className="w-full lg:w-56 shrink-0">
@@ -54,15 +94,9 @@ export default function ListingsPage({ searchParams }: Props) {
         </div>
 
         {/* Grid */}
-        <div className="flex-1">
-          <Suspense
-            fallback={
-              <div className="flex justify-center py-20">
-                <Spinner size="lg" />
-              </div>
-            }
-          >
-            <ListingsGrid listings={PLACEHOLDER_LISTINGS} />
+        <div className="flex-1 min-w-0">
+          <Suspense fallback={<ListingsGridSkeleton count={10} />}>
+            <ListingsSection searchParams={searchParams} />
           </Suspense>
         </div>
       </div>

--- a/apps/web/src/lib/listings.ts
+++ b/apps/web/src/lib/listings.ts
@@ -1,0 +1,264 @@
+import { prisma, Game, CardCondition, CardLanguage, ListingStatus, Prisma } from "@cardbuy/db";
+import type { CardListingData } from "@/components/listings/CardListingCard";
+
+// ---------------------------------------------------------------------------
+// Tipos públicos
+// ---------------------------------------------------------------------------
+
+export interface ListingsFilters {
+  game?: string;
+  condition?: string;
+  language?: string;
+  minPrice?: string;
+  maxPrice?: string;
+  sort?: "price_asc" | "price_desc" | "newest";
+  page?: number;
+  limit?: number;
+  /** Incluir listings agotados (stock = 0 / quantity = 0) */
+  includeOutOfStock?: boolean;
+}
+
+export interface PaginatedListings {
+  listings: CardListingData[];
+  total: number;
+  page: number;
+  limit: number;
+  hasNextPage: boolean;
+}
+
+export interface ListingDetail extends CardListingData {
+  description?: string;
+  setName?: string;
+  setCode?: string;
+  isFoil: boolean;
+  isGraded: boolean;
+  shippingCost: number;
+  freeShipping: boolean;
+  shippingDays: number;
+}
+
+// ---------------------------------------------------------------------------
+// Mappers — UI strings ↔ Prisma enums
+// ---------------------------------------------------------------------------
+
+const GAME_TO_DB: Record<string, Game> = {
+  pokemon:          Game.POKEMON,
+  magic:            Game.MAGIC_THE_GATHERING,
+  mtg:              Game.MAGIC_THE_GATHERING,
+  yugioh:           Game.YUGIOH,
+  onepiece:         Game.ONE_PIECE,
+  lorcana:          Game.LORCANA,
+  dragonball:       Game.DRAGON_BALL,
+  "flesh-and-blood": Game.FLESH_AND_BLOOD,
+  fab:              Game.FLESH_AND_BLOOD,
+  digimon:          Game.DIGIMON,
+  vanguard:         Game.VANGUARD,
+};
+
+const DB_TO_GAME: Record<Game, string> = {
+  [Game.POKEMON]:            "pokemon",
+  [Game.MAGIC_THE_GATHERING]:"magic",
+  [Game.YUGIOH]:             "yugioh",
+  [Game.ONE_PIECE]:          "onepiece",
+  [Game.LORCANA]:            "lorcana",
+  [Game.DRAGON_BALL]:        "dragonball",
+  [Game.FLESH_AND_BLOOD]:    "flesh-and-blood",
+  [Game.DIGIMON]:            "digimon",
+  [Game.VANGUARD]:           "vanguard",
+};
+
+const CONDITION_TO_DB: Record<string, CardCondition> = {
+  NM:  CardCondition.NEAR_MINT,
+  LP:  CardCondition.LIGHTLY_PLAYED,
+  MP:  CardCondition.MODERATELY_PLAYED,
+  HP:  CardCondition.HEAVILY_PLAYED,
+  DMG: CardCondition.DAMAGED,
+};
+
+const DB_TO_CONDITION: Record<CardCondition, string> = {
+  [CardCondition.NEAR_MINT]:          "NM",
+  [CardCondition.LIGHTLY_PLAYED]:     "LP",
+  [CardCondition.MODERATELY_PLAYED]:  "MP",
+  [CardCondition.HEAVILY_PLAYED]:     "HP",
+  [CardCondition.DAMAGED]:            "DMG",
+};
+
+// Note: UI uses "JP", DB uses CardLanguage.JA
+const LANGUAGE_TO_DB: Record<string, CardLanguage> = {
+  ES: CardLanguage.ES,
+  EN: CardLanguage.EN,
+  FR: CardLanguage.FR,
+  DE: CardLanguage.DE,
+  IT: CardLanguage.IT,
+  PT: CardLanguage.PT,
+  JP: CardLanguage.JA,
+  JA: CardLanguage.JA,
+  KO: CardLanguage.KO,
+  ZH: CardLanguage.ZH,
+};
+
+const DB_TO_LANGUAGE: Record<CardLanguage, string> = {
+  [CardLanguage.ES]: "ES",
+  [CardLanguage.EN]: "EN",
+  [CardLanguage.FR]: "FR",
+  [CardLanguage.DE]: "DE",
+  [CardLanguage.IT]: "IT",
+  [CardLanguage.PT]: "PT",
+  [CardLanguage.JA]: "JP",
+  [CardLanguage.KO]: "KO",
+  [CardLanguage.ZH]: "ZH",
+};
+
+export function mapGameToDb(game: string): Game | undefined {
+  return GAME_TO_DB[game.toLowerCase()];
+}
+
+export function mapConditionToDb(condition: string): CardCondition | undefined {
+  return CONDITION_TO_DB[condition.toUpperCase()];
+}
+
+export function mapLanguageToDb(language: string): CardLanguage | undefined {
+  return LANGUAGE_TO_DB[language.toUpperCase()];
+}
+
+export function mapDbToGame(game: Game): string {
+  return DB_TO_GAME[game] ?? game.toLowerCase();
+}
+
+export function mapDbToCondition(condition: CardCondition): string {
+  return DB_TO_CONDITION[condition] ?? condition;
+}
+
+export function mapDbToLanguage(language: CardLanguage): string {
+  return DB_TO_LANGUAGE[language] ?? language;
+}
+
+// ---------------------------------------------------------------------------
+// Tipo resultado de la query Prisma (inferido)
+// ---------------------------------------------------------------------------
+
+const listingWithRelations = Prisma.validator<Prisma.CardListingDefaultArgs>()({
+  include: {
+    card: { include: { set: true } },
+    seller: true,
+  },
+});
+
+type DbListingWithRelations = Prisma.CardListingGetPayload<typeof listingWithRelations>;
+
+// ---------------------------------------------------------------------------
+// Mapper DB → CardListingData
+// ---------------------------------------------------------------------------
+
+export function mapDbToCardListingData(listing: DbListingWithRelations): CardListingData {
+  return {
+    id:               listing.id,
+    title:            listing.card.name,
+    price:            Number(listing.price),
+    condition:        mapDbToCondition(listing.condition),
+    language:         mapDbToLanguage(listing.language),
+    game:             mapDbToGame(listing.card.game),
+    sellerName:       listing.seller.shopName,
+    imageUrl:         listing.card.imageUrl ?? undefined,
+    stock:            listing.quantity,
+    sellerRating:     listing.seller.averageRating,
+    sellerReviewCount: listing.seller.totalReviews,
+    // Vendedor verificado si ha completado onboarding de Stripe
+    isVerified:       listing.seller.stripeOnboarded,
+  };
+}
+
+export function mapDbToListingDetail(listing: DbListingWithRelations): ListingDetail {
+  return {
+    ...mapDbToCardListingData(listing),
+    description:  listing.description ?? undefined,
+    setName:      listing.card.set.name,
+    setCode:      listing.card.set.code,
+    isFoil:       listing.isFoil,
+    isGraded:     listing.isGraded,
+    shippingCost: Number(listing.shippingCost),
+    freeShipping: listing.freeShipping,
+    shippingDays: listing.shippingDays,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Service — queries Prisma
+// ---------------------------------------------------------------------------
+
+export async function getListings(filters: ListingsFilters): Promise<PaginatedListings> {
+  const page  = Math.max(1, filters.page  ?? 1);
+  const limit = Math.min(100, Math.max(1, filters.limit ?? 20));
+  const skip  = (page - 1) * limit;
+
+  // Construir where
+  const where: Prisma.CardListingWhereInput = {
+    status: ListingStatus.ACTIVE,
+    ...(filters.includeOutOfStock ? {} : { quantity: { gt: 0 } }),
+  };
+
+  if (filters.game) {
+    const dbGame = mapGameToDb(filters.game);
+    if (dbGame) where.card = { game: dbGame };
+  }
+
+  if (filters.condition) {
+    const dbCondition = mapConditionToDb(filters.condition);
+    if (dbCondition) where.condition = dbCondition;
+  }
+
+  if (filters.language) {
+    const dbLanguage = mapLanguageToDb(filters.language);
+    if (dbLanguage) where.language = dbLanguage;
+  }
+
+  if (filters.minPrice ?? filters.maxPrice) {
+    where.price = {};
+    if (filters.minPrice) where.price.gte = new Prisma.Decimal(filters.minPrice);
+    if (filters.maxPrice) where.price.lte = new Prisma.Decimal(filters.maxPrice);
+  }
+
+  // Ordenación
+  let orderBy: Prisma.CardListingOrderByWithRelationInput;
+  switch (filters.sort) {
+    case "price_asc":  orderBy = { price: "asc" }; break;
+    case "price_desc": orderBy = { price: "desc" }; break;
+    case "newest":
+    default:           orderBy = { createdAt: "desc" };
+  }
+
+  const [items, total] = await Promise.all([
+    prisma.cardListing.findMany({
+      where,
+      orderBy,
+      skip,
+      take: limit,
+      include: {
+        card: { include: { set: true } },
+        seller: true,
+      },
+    }),
+    prisma.cardListing.count({ where }),
+  ]);
+
+  return {
+    listings:    items.map(mapDbToCardListingData),
+    total,
+    page,
+    limit,
+    hasNextPage: page * limit < total,
+  };
+}
+
+export async function getListingById(id: string): Promise<ListingDetail | null> {
+  const listing = await prisma.cardListing.findUnique({
+    where: { id },
+    include: {
+      card: { include: { set: true } },
+      seller: true,
+    },
+  });
+
+  if (!listing) return null;
+  return mapDbToListingDetail(listing);
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,18 +2,42 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "module": "esnext",
     "moduleResolution": "bundler",
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@cardbuy/db": ["../../packages/db/src/index.ts"],
-      "@cardbuy/types": ["../../packages/types/src/index.ts"]
-    }
+      "@/*": [
+        "./src/*"
+      ],
+      "@cardbuy/db": [
+        "../../packages/db/src/index.ts"
+      ],
+      "@cardbuy/types": [
+        "../../packages/types/src/index.ts"
+      ]
+    },
+    "allowJs": true,
+    "noEmit": true,
+    "isolatedModules": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/docs/automation/setup.md
+++ b/docs/automation/setup.md
@@ -25,6 +25,13 @@ gh auth login
 # Selecciona: GitHub.com → HTTPS → Authenticate with browser
 ```
 
+El token necesita los scopes: `repo`, `project`, `write:discussion`.
+Si ya tienes sesión pero faltan scopes:
+
+```bash
+gh auth refresh -s project
+```
+
 ### 3. Crear labels en GitHub
 
 ```bash
@@ -51,47 +58,103 @@ Ve a: https://github.com/juanmbarrios/cardbuy/settings/secrets/actions
 
 1. Ve a https://github.com/juanmbarrios?tab=projects
 2. Crea un proyecto nuevo → "Board" view
-3. Añade las columnas: `Todo`, `In Progress`, `In Review`, `Blocked`, `Waiting for Credentials`, `Waiting for Review`, `Done`
-4. Ve al proyecto y anota el número en la URL: `github.com/users/juanmbarrios/projects/[NÚMERO]`
-5. En el repo, ve a Settings → Secrets → Variables y crea una variable `PROJECT_NUMBER` con ese número
+3. Añade exactamente estas columnas (en este orden):
+   - `Todo`
+   - `In Progress`
+   - `In Review`
+   - `Blocked`
+   - `Waiting for Credentials`
+   - `Waiting for Review`
+   - `Done`
+4. Anota el número en la URL: `github.com/users/juanmbarrios/projects/[NÚMERO]`
+5. Añade `PROJECT_NUMBER=[NÚMERO]` a tu `.env` local
 
 ### 6. Iniciar el servidor local
 
 ```bash
-# Opción 1: desarrollo con hot reload
-pnpm dev
-
-# Opción 2: producción local con PM2
-pnpm build
-pm2 start deploy/ecosystem.config.js
+docker compose -f infra/docker-compose.yml up -d   # base de datos
+pnpm dev                                             # servidor Next.js
 ```
 
-Verificar: http://localhost:3000/api/health → `{"status": "ok"}`
+Verificar: http://localhost:3000
 
 ---
 
-## Workflow diario
+## Workflow de issues (con skills de Claude Code)
+
+### Crear una issue nueva
+
+```
+/new-issue descripción de lo que quieres implementar
+```
+
+Claude:
+1. Genera la issue estructurada con criterios de aceptación
+2. La sube al repo con `gh issue create`
+3. La añade automáticamente al Kanban en columna **Todo**
+4. Muestra la URL de la issue
+
+### Implementar una issue
+
+```
+/implement-issue N
+```
+
+Claude:
+1. Mueve la issue a **In Progress** en el Kanban
+2. Lee la issue y planifica
+3. Implementa todos los criterios de aceptación
+4. Abre una PR apuntando a `develop`
+5. Mueve la issue al estado final según el resultado:
+
+| Resultado | Columna Kanban |
+|-----------|---------------|
+| PR creada, todo correcto | **In Review** |
+| Faltan API keys o secrets | **Waiting for Credentials** |
+| Depende de otra issue sin completar | **Blocked** |
+| Necesita decisión del usuario | **Waiting for Review** |
+
+### Reintentar una issue bloqueada
+
+Si una issue quedó en Blocked, Waiting for Credentials, etc., una vez resuelto el bloqueo:
+
+```
+/implement-issue N
+```
+
+Claude retoma la implementación y vuelve a mover la issue a **In Progress**.
+
+### Flujo completo de una issue
+
+```
+Todo → In Progress → In Review → (merge PR) → Done
+```
+
+El paso de **In Review → Done** lo hace el desarrollador manualmente al mergear la PR en GitHub.
+
+---
+
+## Otros comandos útiles
 
 ```bash
 # Inicio del día
-pnpm dev                    # arranca el servidor
-/standup                    # en el chat: resumen de actividad
+/standup                    # resumen de actividad reciente
 
-# Crear una issue
-/new-issue [descripción]    # en el chat: genera issue estructurada
-# → copiar en GitHub Issues
+# Revisión de código antes de PR
+/pr-review                  # revisión de la PR actual
 
-# Trabajar en una issue
-git checkout feat/issue-N   # rama creada automáticamente al añadir label ai-implement
-# ... trabajar ...
-/commit                     # en el chat: genera mensaje de commit
+# Revisión semanal del backlog
+/detect-duplicates          # detecta issues solapadas
+/check-todos                # audita deuda técnica (TODO/FIXME en código)
 
-# Antes de abrir un PR
-/pr-review                  # en el chat: revisión previa
-git push origin feat/issue-N
-gh pr create --fill
-
-# Revisión semanal
-/detect-duplicates          # en el chat: detecta solapamientos en el backlog
-/check-todos                # en el chat: audita deuda técnica
+# Commit estructurado
+/commit                     # genera mensaje de commit según cambios staged
 ```
+
+---
+
+## Notas de configuración
+
+- `PROJECT_NUMBER` debe estar en `.env` para que el Kanban funcione automáticamente
+- Si `gh` no tiene el scope `project`, ejecuta `gh auth refresh -s project`
+- Las columnas del Kanban deben llamarse exactamente como se indica en el paso 5 (sensible a mayúsculas)

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [".env"],
-  "pipeline": {
+  "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]


### PR DESCRIPTION
## Resumen

Implementación de la issue #21. Reemplaza todos los datos hardcodeados (PLACEHOLDER_LISTINGS / MOCK_LISTINGS) por fetch real a PostgreSQL vía Prisma, con dos API Routes, un servicio de datos y 31 tests nuevos.

## Cambios realizados

- **`lib/listings.ts`** — servicio central con `getListings` (filtros + paginación) y `getListingById`; mappers bidireccionales `Game / CardCondition / CardLanguage` DB↔UI con soporte de aliases (mtg→magic, jp→ja, fab→flesh-and-blood)
- **`api/listings/route.ts`** — `GET /api/listings` con filtros opcionales (`game`, `condition`, `language`, `minPrice`, `maxPrice`, `sort`) y paginación (`page`, `limit`); respuesta incluye `total` y `hasNextPage`
- **`api/listings/[id]/route.ts`** — `GET /api/listings/:id` con relaciones `Card + CardSet + SellerProfile`; 404 si no existe
- **`app/listings/page.tsx`** — Server Component que llama a `/api/listings`, muestra skeleton mientras carga y `ErrorState` en fallo
- **`app/listings/[id]/page.tsx`** — Server Component que llama a `/api/listings/:id`; añade nombre de set, envío, foil y gradada al detalle
- **`__tests__/listings-service.test.ts`** — 31 tests de mappers (round-trips, aliases, case-insensitive, valores desconocidos)

## Criterios de aceptación

- [x] `GET /api/listings` con filtros y paginación (`total`, `hasNextPage`)
- [x] `GET /api/listings/[id]` con Card, CardSet y SellerProfile; 404 si no existe
- [x] `listings/page.tsx` usa datos reales (sin PLACEHOLDER_LISTINGS)
- [x] `listings/[id]/page.tsx` usa datos reales (sin MOCK_LISTINGS)
- [x] Solo listings con `status = ACTIVE` y `quantity > 0` (configurable con `includeOutOfStock`)
- [x] Paginación con `page` + `limit` + `hasNextPage`
- [x] 31 tests de mappers — 42 tests totales passing

## Cómo probar

1. Asegúrate de tener `DATABASE_URL` configurado en `.env`
2. Ejecuta `pnpm --filter @cardbuy/db db:migrate` para aplicar migraciones
3. Opcionalmente `pnpm --filter @cardbuy/db db:seed` para datos de prueba
4. `pnpm dev` desde la raíz
5. `GET http://localhost:3000/api/listings?game=pokemon&sort=price_asc` → devuelve JSON paginado
6. `GET http://localhost:3000/api/listings/[id-real]` → devuelve detalle o 404
7. Abre `/listings` — muestra datos reales o ErrorState si la BD no está disponible
8. `pnpm --filter @cardbuy/web test` → 42 tests ✓

> **Nota:** Esta PR asume que la BD tiene datos. Sin seed, `/listings` mostrará el EmptyState (comportamiento correcto).

Closes #21

🤖 Implementado con [Claude Code](https://claude.com/claude-code)